### PR TITLE
Clarify 'no "or"s' for regex rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ScryfallCardGolf
 Card Golf: Get a set of two random cards in as few characters as possible
 
-Every day, a randomly selected pair of cards will be posted to Twitter. You then need to use [ScryFall](https://scryfall.com)'s search feature to get only the two specified cards as the return results. The catch is to do this in as few characters as possible AND without using an 'or' modifier (whether it be the word 'or' or a regex or like '|')
+Every day, a randomly selected pair of cards will be posted to Twitter. You then need to use [ScryFall](https://scryfall.com)'s search feature to get only the two specified cards as the return results. The catch is to do this in as few characters as possible AND without using an 'or' modifier (whether it be the word 'or' or a regex '|' operator)
 
 You can check out all the contests, winners, and responses via the twitter hashtag [#ScryfallCardGolf](https://twitter.com/search?f=tweets&vertical=default&q=ScryfallCardGolf&src=typd). Feel free to join along!!


### PR DESCRIPTION
Small tweak to clear up that regexes can be used but not the '|' pattern (at least that's my understanding of the regex rule?)